### PR TITLE
Unsplash.it has changed to Lorem Picsum (https://picsum.photos)

### DIFF
--- a/image/Image.js
+++ b/image/Image.js
@@ -4,7 +4,7 @@ module.exports = {
     PlaceholdIt: require('./providers/PlaceholdIt'),
     PlaceImg: require('./providers/PlaceImg'),
     DummyImage: require('./providers/DummyImage'),
-    UnsplashIt: require('./providers/UnsplashIt'),
+    LoremPicsum: require('./providers/LoremPicsum'),
     FakeImg: require('./providers/FakeImg')
   },
 

--- a/image/providers/LoremPicsum.js
+++ b/image/providers/LoremPicsum.js
@@ -4,6 +4,6 @@ module.exports = {
 
     var pieces = size.split('x');
 
-    return 'https://unsplash.it/' + pieces[0] + '/' + pieces[1];
+    return 'https://picsum.photos/' + pieces[0] + '/' + pieces[1] + '/?random';
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 
-var http = require('http');
-var https = require('https');
+var http = require('follow-redirects').http;
+var https = require('follow-redirects').https;
 var fs = require('fs');
 var random = require('random-string');
 var Image = require('./image/Image');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "public",
     "domain",
     "unsplash.it",
+    "lorempicsum",
     "fakeimg.pl",
     "fake images",
     "fakeimg"
@@ -47,7 +48,8 @@
   "homepage": "https://github.com/ecrmnn/spaceholder",
   "dependencies": {
     "commander": "^2.8.1",
-    "random-string": "^0.1.2"
+    "random-string": "^0.1.2",
+    "follow-redirects": "^1.2.5"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test/Factory.js
+++ b/test/Factory.js
@@ -57,11 +57,11 @@ describe('Image Providers', function () {
       .to.equal('https://dummyimage.com/400x400/000/fff');
   });
 
-  it('returns UnsplashIt URL', function () {
-    Image.setProvider('UnsplashIt');
+  it('returns LoremPicsum URL', function () {
+    Image.setProvider('LoremPicsum');
 
     expect(Image.getImageUrl(size))
-      .to.equal('https://unsplash.it/400/400');
+      .to.include('https://picsum.photos/400/400');
   });
 
   it('returns FakeImg URL', function () {


### PR DESCRIPTION
https://unsplash.it/ is now redirecting to https://picsum.photos/ and their image generation is now happening there. As a result unsplash.it images in spaceholder just don't work.

This PR resolves that.

Wasn't sure how to change the readme to reflect this so haven't included that in this PR.