### PR TITLE
Removes broken provider and fixes LoremPicsum

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### What is it?
 Spaceholder makes it easy to download placeholder images when you need them.
-Images are downloaded from LoremPixel.com, Placehold.it, PlaceIMG.com, Dummyimage.com, Unsplash.it.
+Images are downloaded from Picsum.photos, PlaceIMG.com, Dummyimage.com, Fakeimg.pl.
 
 ### Installation
 Spaceholder requires that you have Node.js installed on you computer
@@ -32,18 +32,16 @@ spaceholder -s 800x600
 # Downloads 1 image (800x600px) into current directory
 ```
 ```bash
-spaceholder -n 50 -s 800x600 -p LoremPixel
-# Downloads 50 images (800x600px) from LoremPixel into current directory
+spaceholder -n 50 -s 800x600 -p LoremPicsum
+# Downloads 50 images (800x600px) from LoremPicsum into current directory
 # If no --provider / -p is specified, each image is downloaded from a random provider
 ```
 
 ### Providers / Sources
 - [Dummy Image](http://dummyimage.com)
 - [FakeImg](fakeimg.pl)
-- [Lorem Pixel](http://lorempixel.com)
-- [PlaceholdIt](https://placehold.it)
+- [Picsum Photos](http://picsum.photos)
 - [PlaceImg](http://placeimg.com)
-- [UnsplashIt](https://unsplash.it)
 
 ### Contributors
 - [mrtnsn](https://github.com/mrtnsn)

--- a/image/Image.js
+++ b/image/Image.js
@@ -1,6 +1,5 @@
 module.exports = {
   providers: {
-    LoremPixel: require('./providers/LoremPixel'),
     PlaceImg: require('./providers/PlaceImg'),
     DummyImage: require('./providers/DummyImage'),
     LoremPicsum: require('./providers/LoremPicsum'),

--- a/image/providers/LoremPixel.js
+++ b/image/providers/LoremPixel.js
@@ -1,9 +1,0 @@
-module.exports = {
-  getImageUrl: function (size) {
-    'use strict';
-
-    var pieces = size.split('x');
-
-    return 'http://lorempixel.com/' + pieces[0] + '/' + pieces[1] + '/';
-  }
-};

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 #! /usr/bin/env node
 
-var http = require('http');
-var https = require('https');
+var followRedirects = require('follow-redirects');
+var http = followRedirects.http;
+var https = followRedirects.https;
 var fs = require('fs');
 var random = require('random-string');
 var Image = require('./image/Image');
 var readline = require('readline');
+
+followRedirects.maxRedirects = 10;
 
 /* Require Commander configuration */
 var program = require('./commanderConfig');

--- a/package.json
+++ b/package.json
@@ -16,15 +16,13 @@
   "keywords": [
     "placeholder",
     "images",
-    "lorempixel",
-    "placehold.it",
     "placeimg",
     "dummyimage",
     "dummy image",
     "public",
     "domain",
-    "unsplash.it",
     "lorempicsum",
+    "lorem picsum",
     "fakeimg.pl",
     "fake images",
     "fakeimg"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "homepage": "https://github.com/ecrmnn/spaceholder",
   "dependencies": {
     "commander": "^2.8.1",
+    "follow-redirects": "^1.15.0",
     "random-string": "^0.1.2"
   },
   "devDependencies": {

--- a/test/Factory.js
+++ b/test/Factory.js
@@ -29,13 +29,6 @@ describe('Image Providers', function () {
 
   var size = '400x400';
 
-  it('returns Lorem Pixel URL', function () {
-    Image.setProvider('LoremPixel');
-
-    expect(Image.getImageUrl(size))
-      .to.equal('http://lorempixel.com/400/400/');
-  });
-
   it('returns PlaceImg URL', function () {
     Image.setProvider('PlaceImg');
 


### PR DESCRIPTION
This PR does the following:
* Removes the broken provider `LoremPixel`
* Adds logic for following redirects in order to fix the broken provider `LoremPicsum`
* Updates readme and package.json by removing old providers that no longer exists in this project